### PR TITLE
fix relay handshake blockage

### DIFF
--- a/internal/relay/client_transporter.go
+++ b/internal/relay/client_transporter.go
@@ -159,12 +159,13 @@ func (c *clientTransporterImpl) Connect(ctx context.Context) error {
 		IsPrimary: c.isPrimary,
 	}
 
+	c.chWrite <- Packet{
+		Type:    message.PacketType_Handshake,
+		Message: msg,
+	}
+
 	select {
 	case <-c.hsSignal:
-		c.chWrite <- Packet{
-			Type:    message.PacketType_Handshake,
-			Message: msg,
-		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
The handshake process should be:
```
client                                          server
Connect()            --  Dial TCP conn -->         |
    |                 <-Conn established--         |
    |                                              |
Connect()           -- PacketType_Handshake ->  Read()
    |                                              |
onHandshakeAck()    <- PacketHandshakeAck --    onHandshake()
    |
setState()
    |
close(hsSignal)
    |
Connect() func finishes after releasing the select{}
```

Therefore the sending of the `PacketType_Handshake` must come before releasing the `hsSignal`. It cannot hide behind the select case. Otherwise the handshake will be blocked