### PR TITLE
fix bsdDel func

### DIFF
--- a/node/device/router_bsd.go
+++ b/node/device/router_bsd.go
@@ -38,7 +38,7 @@ func bsdAdd(devName string, _ netaddr.IP, target netaddr.IPPrefix) error {
 func bsdDel(devName string, _ netaddr.IP, target netaddr.IPPrefix) error {
 	net := target.IPNet()
 	nip := net.IP.Mask(net.Mask)
-	nstr := fmt.Sprintf("%v/%d", nip, target.Bits)
+	nstr := fmt.Sprintf("%v/%d", nip, target.Bits())
 	del := "del"
 	if runtime.GOOS == "darwin" {
 		del = "delete"


### PR DESCRIPTION
When running tests, found this:
```
# github.com/pairmesh/pairmesh/node/device
node/device/router_bsd.go:41:10: Sprintf format %d arg target.Bits is a func value, not called
```